### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-pypdf2
+pypdf2 == 1.26.0
 cryptography


### PR DESCRIPTION
According to https://github.com/SHMinger/ScienceDecrypting, the version of pypdf2 should be 1.26.0. Otherwise, there might be version error.